### PR TITLE
hotfix: typo in `dockerfile`

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:latest
 
 COPY assets /usr/share/nginx/html/assets
-COPY image /usr/share/nginx/html/image
 COPY css /usr/share/nginx/html/css
+COPY js /usr/share/nginx/html/js
 COPY index.html /usr/share/nginx/html


### PR DESCRIPTION
Typo in `dockerfile`